### PR TITLE
Add hallucination probe on intermediate hidden states

### DIFF
--- a/FULL_LIST.md
+++ b/FULL_LIST.md
@@ -4476,6 +4476,16 @@
 ## Interpretability
 
 <details>
+<summary>Interpretability: 2026</summary>
+
+- DRIFT: Detecting Representational Inconsistencies for Factual Truthfulness. [[paper]](https://arxiv.org/abs/2601.14210)
+  - Rohan Bhatnagar, Youran Sun, Chi Andrew Zhang, Yixin Wen, Haizhao Yang.
+  - Key Word: Hallucination Detection; Probing; Internal Representations; Factuality.
+  - <details><summary>Digest</summary> Final-layer logits discard much of the model's internal uncertainty. The authors show that intermediate-late hidden states still carry that signal and train a small probe (3M-37M parameters) on those states to predict whether each generated answer is factual. The probe runs in parallel with generation, adding under 0.1% overhead. It reaches state-of-the-art AUROC on 10 of 12 settings, beats prior methods by up to 13 points, generalizes across datasets without retraining, and hits 97.7% accuracy after abstaining on the 60% most uncertain answers.
+
+</details>
+
+<details>
 <summary>Interpretability: 2024</summary>
 
 - Concept Bottleneck Language Models For protein design. [[paper]](https://arxiv.org/abs/2411.06090)

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ Daily updating from ArXiv. The preview README only includes papers submitted to 
   - Key Word: Diffusion Model; LLM Activations; Interpretability.
   - <details><summary>Digest</summary> The paper proposes training generative “meta-models” (diffusion models) on a massive dataset (~1B residual stream activations) to learn a neural network’s internal-state distribution without relying on rigid assumptions like PCA or sparse autoencoders. They find the diffusion training loss scales smoothly with compute and is a reliable predictor of downstream usefulness: as loss drops, the learned prior improves the fluency of steering/intervention methods and the meta-model’s units become more concept-isolating, reflected in better sparse probing scores. 
 
+- DRIFT: Detecting Representational Inconsistencies for Factual Truthfulness. [[paper]](https://arxiv.org/abs/2601.14210)
+  - Rohan Bhatnagar, Youran Sun, Chi Andrew Zhang, Yixin Wen, Haizhao Yang.
+  - Key Word: Hallucination Detection; Probing; Internal Representations; Factuality.
+  - <details><summary>Digest</summary> Final-layer logits discard much of the model's internal uncertainty. The authors show that intermediate-late hidden states still carry that signal and train a small probe (3M-37M parameters) on those states to predict whether each generated answer is factual. The probe runs in parallel with generation, adding under 0.1% overhead. It reaches state-of-the-art AUROC on 10 of 12 settings, beats prior methods by up to 13 points, generalizes across datasets without retraining, and hits 97.7% accuracy after abstaining on the 60% most uncertain answers.
+
 ### 2025
 
 - Priors in Time: Missing Inductive Biases for Language Model Interpretability. [[paper]](https://arxiv.org/abs/2511.01836)


### PR DESCRIPTION
Adds DRIFT (arXiv:2601.14210) to Interpretability/2026.

The paper trains a small probe on intermediate-late hidden states to detect hallucinations. It generalizes across datasets without retraining and adds <0.1% overhead to generation. Format mirrors PR #22 (entry in README, new year-block in FULL_LIST).